### PR TITLE
Support syntax highlight in code block with filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,39 @@ https://github.com/kmuto/review/blob/v2-stable/doc/format.md
 
 ![Sample](https://raw.githubusercontent.com/tokorom/vim-review/images/sample.png)
 
+## Support syntax highlight in code block with filetype
+
+### Usage
+
+- You can include multiple filetypes
+
+```vim
+let g:vim_review#include_filetypes = ['swift']
+```
+
+### Supported operations
+
+* `list`
+* `listnum`
+* `emlist`
+* `emlistnum`
+
+```swift
+//list[sample][Sample][swift]{
+class Sample {
+  func say(message: String) {
+    print(message)
+  }
+}
+//}
+```
+
+### Other usage
+
+- When explicitly specifying the syntax file
+
+```vim
+let g:vim_review#include_grouplists = {'swift': 'syntax/swift.vim'}
+```
+
 

--- a/ftplugin/review.vim
+++ b/ftplugin/review.vim
@@ -1,1 +1,12 @@
 setl commentstring=#@#\ %s
+
+if !exists('g:vim_review#include_filetypes')
+  let g:vim_review#include_filetypes = []
+endif
+
+if !exists('g:vim_review#include_grouplists')
+  let g:vim_review#include_grouplists = {}
+  for ft in g:vim_review#include_filetypes
+    let g:vim_review#include_grouplists[ft] = 'syntax/' . ft . '.vim'
+  endfor
+endif

--- a/syntax/review.vim
+++ b/syntax/review.vim
@@ -7,6 +7,7 @@ if exists("b:current_syntax")
 endif
 
 " ----------
+" syntax
 
 syn case match
 
@@ -20,13 +21,13 @@ syn region reviewInlineStyleCommand transparent oneline
       \ start="@<\%\(kw\|bou\|ami\|u\|b\|i\|strong\|em\|tt\|tti\|ttb\|code\|tcy\)>{"
       \ end="}"
 
-syn region reviewBlockCommand transparent
+syn region reviewBlockCommand transparent keepend
       \ matchgroup=reviewBlockDeclaration start="^//\w\+\[\?.*{\s*$" end="^//}\s*$"
 
 syn match reviewBlockCommandWithoutContent
       \ "^//\w\+\[.*[^{]\s*$"
 syn match reviewControlCommand
-      \ "^//\%\(noindent\|blankline\|linebreak\|pagebreak\)\s*$"
+      \ "^//\<\%\(noindent\|blankline\|linebreak\|pagebreak\)\>\s*$"
 
 syn region reviewItemize transparent oneline
       \ matchgroup=reviewItemizePrefix start="^\s\+\*\+\s\+" end="$"
@@ -37,15 +38,15 @@ syn region reviewDefinitionList transparent oneline
 
 syn match reviewComment contains=reviewTodo
       \ "^#@.*"
-syn region reviewCommentBlock contains=reviewTodo
-      \ start="^//comment\[\?.*{\s*" end="^//}\s*$"
+syn region reviewCommentBlock keepend contains=reviewTodo
+      \ start="^//\<comment\>\[\?.*{\s*" end="^//}\s*$"
 syn region reviewCommentInline oneline contains=reviewTodo
       \ start="@<comment>{" end="}"
 
 syn match reviewPreProcCommand
-      \ "^#@\%\(require\|provide\)\s\+.*"
-syn region reviewPreProcBlockCommand
-      \ start="^#@\%\(mapfile\|maprange\|mapoutput\)(.*).*" end="^#@end\s*$"
+      \ "^#@\<\%\(require\|provide\)\>\s\+.*"
+syn region reviewPreProcBlockCommand keepend
+      \ start="^#@\<\%\(mapfile\|maprange\|mapoutput\)\>(.*).*" end="^#@end\s*$"
 
 syn region reviewWarning oneline
       \ matchgroup=reviewPreProcCommand start="^#@warn(" end=").*$"
@@ -55,6 +56,30 @@ syn keyword reviewTodo MARK TODO FIXME contained
 syn case match
 
 " ----------
+" include other languages
+
+if exists('g:vim_review#include_grouplists')
+  let include_grouplists = g:vim_review#include_grouplists
+  let operations = '\<\%\(list\|listnum\|emlist\|emlistnum\)\>'
+
+  for ft in keys(include_grouplists)
+    let syntaxfile = include_grouplists[ft]
+    execute 'syn include @' . ft . ' ' . syntaxfile
+    let code_block_region = 'start="^//' . operations . '\[.*\[' . ft . '\]{\s*$"'
+          \ . ' end="^//}\s*$"'
+    let groupname = 'reviewCodeBlock_' . ft
+    execute 'syn region ' . groupname . ' keepend contains=@' . ft
+          \ . ' matchgroup=reviewBlockDeclaration'
+          \ . ' ' . code_block_region
+
+    if exists('b:current_syntax')
+      unlet b:current_syntax
+    endif
+  endfor
+endif
+
+" ----------
+" highlight
 
 hi def link reviewHeading Conditional
 hi def link reviewInlineCommand Function


### PR DESCRIPTION
Re:VIEWの`list`、`emlist`、`listnum`、`emlistnum`ブロック内のソースコードをfiletypeに応じてその言語でシンタックスハイライトする機能をサポートした。